### PR TITLE
Changed the /credit endpoint to return the price in pounds

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -91,7 +91,7 @@ func (a *api) depositCoins(w http.ResponseWriter, r *http.Request) {
 func (a *api) getCredit(w http.ResponseWriter, r *http.Request) {
 	a.log(r)
 
-	json.NewEncoder(w).Encode(a.vendingMachine.GetCredit())
+	json.NewEncoder(w).Encode(float64(a.vendingMachine.GetCredit())/100)
 }
 
 func (a *api) buyProduct(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Changed the /credit endpoint to return the price in pounds rather than pence.